### PR TITLE
docs: fix humanoid path typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ git submodule update --init --recursive
     - Agibot G1
     - Agibot G2
     - Ai2 Bot2
-    - ARX Lift (`humannoid/ARX_Lift`)
-    - ARX X7S (`humannoid/ARX_X7S`)
+    - ARX Lift (`humanoid/ARX_Lift`)
+    - ARX X7S (`humanoid/ARX_X7S`)
     - Astribot S1
     - Dobot Atom
     - FiveAges W1
@@ -121,7 +121,7 @@ robots/
   grippers/           # Gripper models and their configurations
   dexhands/           # Dexterous hand models and their configurations
   manipulators/       # Manipulator models, environment samples, and configurations
-  humannoid/          # Humanoid robot models and configurations
+  humanoid/          # Humanoid robot models and configurations
   mobile_base/        # Mobile base models and configurations
   mobile_manipulator/ # Mobile manipulator models and configurations
   sensors/            # Sensor models

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -97,12 +97,12 @@ git submodule update --init --recursive
         - Piper
     - 天机智能 Marvin
     - 睿尔曼 RM75（`Realman_RM75`）
-- **Humanoid（人形机器人）** — 对应 `humannoid/` 下目录名
+- **Humanoid（人形机器人）** — 对应 `humanoid/` 下目录名
     - 智元 G1
     - 智元 G2
     - 智平方 Bot2
-    - 方舟无限 Lift（`humannoid/ARX_Lift`）
-    - 方舟无限 X7S（`humannoid/ARX_X7S`）
+    - 方舟无限 Lift（`humanoid/ARX_Lift`）
+    - 方舟无限 X7S（`humanoid/ARX_X7S`）
     - 星尘智能 S1
     - 越疆 Atom（`Dobot_Atom`）
     - 中科第五纪 W1
@@ -147,7 +147,7 @@ robots/
   grippers/           # 夹爪模型及按功能拆分的配置
   dexhands/           # 灵巧手模型及配置
   manipulators/       # 机械臂模型、环境示例与配置
-  humannoid/          # 人形机器人模型及配置
+  humanoid/          # 人形机器人模型及配置
   mobile_base/        # 移动底盘模型及配置
   mobile_manipulator/ # 移动机械臂模型及配置
   sensors/            # 传感器模型


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- Correct `humannoid` to `humanoid` in the English and Chinese README robot path examples.

Fixes #8

## Test plan
- static validation: `humannoid` appeared 3 time(s) in `README.md` before replacement.
- static validation: `humanoid` is present in `README.md` after patch.
- static validation: `humannoid` is absent from `README.md` after patch.
- static validation: `humannoid` appeared 4 time(s) in `README_zh-CN.md` before replacement.
- static validation: `humanoid` is present in `README_zh-CN.md` after patch.
- static validation: `humannoid` is absent from `README_zh-CN.md` after patch.
- Not run: runtime test suite, because this is a documentation/typo-focused fix validated by static text checks.
